### PR TITLE
Send Slack Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ The script utilises the following environment variables.
 | AWS_REGION            | Yes      | -             | AWS region to connect to                                                    |
 | MIN_SEVERITY          | No       | `ALL`         | Sets the minimum vulnerability severity level to indicate a failure         |
 | MAX_WAIT              | No       | `120`         | Sets how long, in seconds, to wait for ECR scan results to become available |
-| SLACK_DISABLE         | No       | -             | If set and non-empty, will disable sending of Slack reports                 |
-| SLACK_CHANNEL         | Yes      | -             | Slack channel to send scan reports to                                       |
+| SLACK_CHANNEL         | Yes      | -             | Slack channel to send scan reports to. If not set, reports will be disabled |
 | SLACK_WEBHOOK         | Yes      | -             | Slack webhook URL used to send the scan report                              |
 
 ## Parameters
@@ -63,7 +62,6 @@ Use in a pipeline
         IMAGE_NAME: <image_name>
         IMAGE_TAG: <image_tag>
         SLACK_CHANNEL: <slack_channel>
-        SLACK_WEBHOOK: <slack_webhook>
 
       run:
         path: bash
@@ -98,7 +96,6 @@ With Slack-based reporting of scan results disabled
         AWS_REGION: eu-west-2
         IMAGE_NAME: <image_name>
         IMAGE_TAG: <image_tag>
-        SLACK_DISABLE: true
 
       run:
         path: bash

--- a/resources/ecr-scan-check.py
+++ b/resources/ecr-scan-check.py
@@ -46,11 +46,10 @@ def check_environment_variables():
         sys.exit(1)
 
     required_slack_vars = [
-        'SLACK_CHANNEL',
         'SLACK_WEBHOOK',
     ]
 
-    if not os.getenv("SLACK_DISABLE"):
+    if os.getenv("SLACK_CHANNEL"):
         missing_slack_vars = []
         for env_var in required_slack_vars:
             if os.getenv(env_var) is None:
@@ -247,8 +246,11 @@ if __name__ == "__main__":
     report_url = generate_report_url(ecr_imagedata, os.environ.get("AWS_REGION"))
 
     # Send a slack report if not disabled
-    if os.environ.get("SLACK_DISABLE") is None:
+    if os.environ.get("SLACK_CHANNEL"):
+        log_output("Info", "Sending scan report to Slack.")
         send_slack_report(vulnerabilities, report_url, args.imagerepo, args.imagetag)
+    else:
+        log_output("Info", "Scan reporting disabled.")
 
     if vulnerabilities:
         log_output("Error", "Vulnerabilities found.")

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,1 +1,2 @@
 boto3
+requests


### PR DESCRIPTION
Updated script behaviour to now send Slack-based scan reports directly, rather than generating a template that is then subsequently used elsewhere. This functionality is now optional.

This change was made to resolve a logic issue where empty Slack messages could be generated and sent from a Concourse pipeline when a script error was encountered and before a scan report was generated. E.g. when a given ECR image and tag didn't exist - the script would error with an "Image not found" error but a slack message could still be triggered based on a non-existent JSON template.

Added new `SLACK_WEBHOOK` and `SLACK_CHANNEL` to supported vars and included as part of checking the environment
Replaced `generate_slack_json` function with new `send_slack_report` function that generates a fully formatted Slack webhook payload, rather than an attachment template
Updated README
Added `requests` to the pip requirements file